### PR TITLE
minify go application Docker image

### DIFF
--- a/backend/compose.debug.yml
+++ b/backend/compose.debug.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   external:
     build:

--- a/backend/compose.yaml
+++ b/backend/compose.yaml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   traefik:
     image: traefik:v2.5

--- a/backend/external/Dockerfile
+++ b/backend/external/Dockerfile
@@ -1,13 +1,13 @@
-FROM golang:1.17-bullseye as build
+FROM golang:1.17-bullseye AS builder
 
+ENV CGO_ENABLED=0
 WORKDIR /control
-ADD . /control
+COPY ./go.mod ./go.sum /control/
+RUN go mod download
+COPY . /control
+RUN make build
+# RUN go build -o /control/app ./cmd/main.go 
 
-RUN go build -o /control/app ./cmd/main.go 
-
-
-FROM ubuntu:20.10
-
-COPY --from=build /control/app /app/app
-
-CMD ["/app/app"]
+FROM gcr.io/distroless/static-debian11:nonroot AS runner
+COPY --from=builder --chown=nonroot:nonroot /control/external /external
+ENTRYPOINT [ "/external" ]

--- a/backend/external/Dockerfile
+++ b/backend/external/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17-bullseye AS builder
+FROM golang:1.19.1-bullseye AS builder
 
 ENV CGO_ENABLED=0
 WORKDIR /control
@@ -6,7 +6,6 @@ COPY ./go.mod ./go.sum /control/
 RUN go mod download
 COPY . /control
 RUN make build
-# RUN go build -o /control/app ./cmd/main.go 
 
 FROM gcr.io/distroless/static-debian11:nonroot AS runner
 COPY --from=builder --chown=nonroot:nonroot /control/external /external

--- a/backend/external/Makefile
+++ b/backend/external/Makefile
@@ -2,6 +2,5 @@ build:
 	GOARCH=amd64 CGO_ENABLED=0 go build -a -tags "netgo" -installsuffix netgo -ldflags="-s -w -extldflags \"-static\"" -o external cmd/main.go
 test:
 	go test -v ./...
-up: build
-	docker-compose build
-	docker-compose up
+up: 
+	docker-compose up --build

--- a/backend/external/docker-compose.yml
+++ b/backend/external/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   external:
     build: .

--- a/backend/internal/Dockerfile
+++ b/backend/internal/Dockerfile
@@ -1,13 +1,12 @@
-FROM golang:1.17-bullseye as build
+FROM golang:1.19.1-bullseye AS builder
 
+ENV CGO_ENABLED=0
 WORKDIR /control
-ADD . /control
+COPY ./go.mod ./go.sum /control/
+RUN go mod download
+COPY . /control/
+RUN make build
 
-RUN go build -o /control/app ./cmd/main.go 
-
-
-FROM ubuntu:20.10
-
-COPY --from=build /control/app /app/app
-
-CMD ["/app/app"]
+FROM gcr.io/distroless/static-debian11:nonroot AS runner
+COPY --from=builder --chown=nonroot:nonroot /control/app /internal
+ENTRYPOINT [ "/internal" ]

--- a/backend/internal/Makefile
+++ b/backend/internal/Makefile
@@ -1,4 +1,4 @@
 build:
-	GOARCH=amd64 CGO_ENABLED=0 go build -a -tags "netgo" -installsuffix netgo -ldflags="-s -w -extldflags \"-static\"" -o external cmd/main.go
+	GOARCH=amd64 CGO_ENABLED=0 go build -a -tags "netgo" -installsuffix netgo -ldflags="-s -w -extldflags \"-static\"" -o app cmd/main.go
 test:
 	go test -v ./...

--- a/backend/internal/internalMock/mock.go
+++ b/backend/internal/internalMock/mock.go
@@ -2,14 +2,15 @@ package main
 
 import (
 	"fmt"
-	grpcPrometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
-	"google.golang.org/grpc"
 	"log"
 	"net"
 	"ueckoken/plarail2021-soft-internal/internal"
 	"ueckoken/plarail2021-soft-internal/pkg/grpcMock"
 	"ueckoken/plarail2021-soft-internal/pkg/serveGrpc"
 	pb "ueckoken/plarail2021-soft-internal/spec"
+
+	grpcPrometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
+	"google.golang.org/grpc"
 )
 
 func main() {

--- a/backend/internal/pkg/station2espIp/parseYaml.go
+++ b/backend/internal/pkg/station2espIp/parseYaml.go
@@ -67,6 +67,6 @@ func (d *StationDetail) GetAngle(state pb.RequestSync_State) (angle int, err err
 	return angle, nil
 }
 
-func (s *stations) Enumerate() []Station{
+func (s *stations) Enumerate() []Station {
 	return s.Stations
 }

--- a/backend/positioning/Dockerfile
+++ b/backend/positioning/Dockerfile
@@ -1,14 +1,12 @@
-FROM golang:1.17-bullseye as build
+FROM golang:1.19.1-bullseye as builder
 
+ENV CGO_ENABLED=0
 WORKDIR /positioning
-ADD . /positioning
+COPY ./go.mod ./go.sum /positioning/
+RUN go mod download
+COPY . /positioning
+RUN make build
 
-RUN go build -o /positioning/app ./cmd/main.go 
-
-FROM ubuntu:20.10
-
-RUN apt-get update
-
-COPY --from=build /positioning/app /app/app
-
-CMD ["/app/app"]
+FROM gcr.io/distroless/static-debian11:nonroot AS runner
+COPY --from=builder --chown=nonroot:nonroot /positioning/main /positioning
+ENTRYPOINT [ "/positioning" ]

--- a/backend/positioning/internal/http.go
+++ b/backend/positioning/internal/http.go
@@ -34,6 +34,7 @@ func (pos PositionReceiver) StartPositionReceiver() {
 
 	http.Handle("/registerPosition", p)
 	http.Handle("/subscribePosition", h)
+	log.Print("listening on :8080")
 	log.Fatal(http.ListenAndServe(":8080", nil))
 }
 

--- a/backend/positioning/pkg/gormHandler/trainState_test.go
+++ b/backend/positioning/pkg/gormHandler/trainState_test.go
@@ -27,9 +27,8 @@ func TestUpdate(t *testing.T) {
 	db.Store(ts)
 	tsO := db.FetchFromTrainId(123)
 	fmt.Println(tsO.States)
-	if !(ts.TrainId==tsO.States[0].TrainId) && !(ts.HallSensorName==tsO.States[0].HallSensorName){
+	if !(ts.TrainId == tsO.States[0].TrainId) && !(ts.HallSensorName == tsO.States[0].HallSensorName) {
 		t.Errorf("error")
 	}
 	t.Errorf("a")
 }
-

--- a/backend/speed/Dockerfile
+++ b/backend/speed/Dockerfile
@@ -1,14 +1,12 @@
-FROM golang:1.17-bullseye as builder
+FROM golang:1.19.1-bullseye AS builder
 
+ENV CGO_ENABLED=0
 WORKDIR /speed
-ADD . /speed
-
-RUN go mod tidy
-
+COPY ./go.mod ./go.sum /speed/
+RUN go mod download
+COPY . /speed
 RUN go build -o /speed/app ./cmd/main.go
 
-FROM ubuntu:20.10 as runner
-
-COPY --from=builder /speed/app /app/app
-
-CMD ["/app/app"]
+FROM gcr.io/distroless/static-debian11:nonroot AS runner
+COPY --from=builder --chown=nonroot:nonroot /speed/app /speed
+ENTRYPOINT [ "/speed" ]

--- a/backend/speed/internal/http.go
+++ b/backend/speed/internal/http.go
@@ -43,6 +43,7 @@ func (s SpeedServer) StartSpeed() {
 	prometheus.MustRegister(s.Speed)
 	http.Handle("/speed", s.ClientHandler)
 	http.Handle("/metrics", promhttp.Handler())
+	log.Println("listening on :8080")
 	log.Fatal(http.ListenAndServe(":8080", nil))
 }
 


### PR DESCRIPTION
#25 をgoのイメージに対して行った

100MB前後のイメージが13MBくらいのイメージになりました。
またroot権限で動かしていたアプリケーションをnonrootのユーザで動かすようにしました。