### PR TITLE
use multi-stage builds for smarter compilation

### DIFF
--- a/frontend/videoCast/Dockerfile.nginx
+++ b/frontend/videoCast/Dockerfile.nginx
@@ -1,9 +1,0 @@
-FROM node:16 AS builder
-WORKDIR /frontend
-COPY ./ /frontend/
-RUN npm i
-RUN npx webpack
-
-FROM nginx
-COPY --from=builder /frontend/*_.js /usr/share/nginx/html/
-COPY ./ /usr/share/nginx/html

--- a/frontend/videoCast/Dockerfile.receiver
+++ b/frontend/videoCast/Dockerfile.receiver
@@ -1,6 +1,12 @@
-FROM nginx
-RUN apt-get update && apt-get -y install nodejs npm
-COPY ./ /usr/share/nginx/html/
-COPY ./skyway_receiver.html /usr/share/nginx/html/index.html
+FROM node:14.20.1-buster-slim as builder
 
-CMD ["bash", "/usr/share/nginx/html/receiver.sh"]
+WORKDIR /app
+COPY package.json package-lock.json /app/
+RUN npm ci
+
+COPY *.js /app/
+RUN npx webpack
+
+FROM nginx:1.20.1-alpine
+COPY --from=builder /app/skyway_receiver_.js /usr/share/nginx/html/
+COPY ./skyway_receiver.html /usr/share/nginx/html/index.html

--- a/frontend/videoCast/Dockerfile.sender
+++ b/frontend/videoCast/Dockerfile.sender
@@ -1,6 +1,12 @@
-FROM nginx
-RUN apt-get update && apt-get -y install nodejs npm
-COPY ./ /usr/share/nginx/html/
-COPY ./momo_sender.html /usr/share/nginx/html/index.html
+FROM node:14.20.1-buster-slim as builder
 
-CMD ["bash", "/usr/share/nginx/html/sender.sh"]
+WORKDIR /app
+COPY package.json package-lock.json /app/
+RUN npm ci
+
+COPY *.js /app/
+RUN npx webpack
+
+FROM nginx:1.20.1-alpine
+COPY --from=builder /app/momo_sender_.js /usr/share/nginx/html/
+COPY ./momo_sender.html /usr/share/nginx/html/index.html

--- a/frontend/videoCast/receiver.sh
+++ b/frontend/videoCast/receiver.sh
@@ -1,4 +1,0 @@
-cd /usr/share/nginx/html && npm i && yes | npx webpack
-rm /usr/share/nginx/html/*momo*
-
-/usr/sbin/nginx -g "daemon off;"

--- a/frontend/videoCast/sender.sh
+++ b/frontend/videoCast/sender.sh
@@ -1,1 +1,0 @@
-cd /usr/share/nginx/html && npm i && yes | npx webpack && /usr/sbin/nginx -g "daemon off;"


### PR DESCRIPTION
やったこと：

- 使われてなさそうなDockerfile.nginx を消去
- nodeイメージによる多段階ビルド
- nginxイメージのバージョンを明示
- nginxイメージをalpineにして軽量化

やってないこと：

- nginxイメージの非root化
  - このPRでは振る舞いを変えないようにしたいのでポート番号は80のまま
- nodeイメージのバージョンアップ
  - 現在 packege-lock.json v1 を利用していて、Node.js v16に上げてしまうと付属のnpmでv2への変換処理が発生して遅くなるため
- Dockerfileでの重複コード
  - Dockerfile.receiver と Dockerfile.sender の先頭8行は全く同じで不吉な臭いがしているが対処すると面倒そうなのでこのPRでは扱いたくない