### PR TITLE
quote 3.10 to be string

### DIFF
--- a/.github/workflows/format_frontend.yml
+++ b/.github/workflows/format_frontend.yml
@@ -69,7 +69,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: "3.10"
           cache: pip
           cache-dependency-path: ./frontend/videoCast/requirements-dev.txt
       - run: pip install -r requirements-dev.txt


### PR DESCRIPTION
```yaml
          python-version: 3.10
```

が3.1として認識されてエラーになってた

https://github.com/ueckoken/plarail2022/actions/runs/3227499183/jobs/5282389328

> Version 3.1 was not found in the local cache
> Error: Version 3.1 with arch x64 not found
> The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json

ダブルクオートで囲んで文字列として認識させる