### PR TITLE
shortcut to receive forever

### DIFF
--- a/frontend/videoCast/one_to_multiple_cast_skyway.py
+++ b/frontend/videoCast/one_to_multiple_cast_skyway.py
@@ -41,13 +41,9 @@ async def handler(websocket, path):
     print(remote_address)
     async with lock:
         connections.append(websocket)
-    while True:
-        # 受信
-        try:
-            received_packet = await websocket.recv()
-        except:
-            break
-        dictionary = json.loads(received_packet)
+
+    async for message in websocket:  # 受信
+        dictionary = json.loads(message)
         # msg_type, room_idで構成
         # connect_senderの時のみ+peer_id
         promises = []


### PR DESCRIPTION
非同期イテレーターを使って記述を少し短縮

> This pattern is so common that websockets provides a shortcut for iterating over messages received on the connection until the client disconnects:
>
> ```python
> async def handler(websocket):
>     async for message in websocket:
>         print(message)
> ```

出典：[Part 1 - Send &amp; receive - websockets 10.3 documentation](https://websockets.readthedocs.io/en/stable/intro/tutorial1.html?highlight=async%20for#bootstrap-the-server)