### PR TITLE
fix #244 with workaround

### DIFF
--- a/manifests/infra/helm/traefik/release.yaml
+++ b/manifests/infra/helm/traefik/release.yaml
@@ -5,10 +5,6 @@ metadata:
   namespace: traefik
 spec:
   interval: 10m
-  values:
-    additionalArguments:
-      - --entryPoints.web.http.redirections.entryPoint.to: websecure
-      - --entryPoints.web.http.redirections.entryPoint.scheme: https
   chart:
     spec:
       chart: traefik

--- a/manifests/infra/traefik/redirect-to-https.yaml
+++ b/manifests/infra/traefik/redirect-to-https.yaml
@@ -1,0 +1,27 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: redirect
+  namespace: traefik
+spec:
+  entryPoints:
+    - web
+  routes:
+    - kind: Rule
+      match: PathPrefix(`/`)
+      priority: 1
+      middlewares:
+        - name: redirect
+      services:
+        - kind: TraefikService
+          name: noop@internal
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: redirect
+  namespace: traefik
+spec:
+  redirectScheme:
+    scheme: https
+    permanent: true


### PR DESCRIPTION
最悪で、8443ポートに飛ばされたので他の方法を使います。webのあらゆるでリッスンさせてhttpsにredirectするだけのIngressRouteを作りました。