### PR TITLE
Impl json2grpc container image definition file

### DIFF
--- a/backend/json2grpc/Dockerfile
+++ b/backend/json2grpc/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.19.3-bullseye AS builder
+
+ENV CGO_ENABLED=0
+WORKDIR /json2grpc
+COPY ./go.mod ./go.sum ./
+RUN go mod download
+COPY . ./
+RUN make build
+
+FROM gcr.io/distroless/static-debian11:nonroot AS runner
+COPY --from=builder --chown=nonroot:nonroot /json2grpc/json2grpc /app
+ENTRYPOINT [ "/app" ]

--- a/backend/json2grpc/main.go
+++ b/backend/json2grpc/main.go
@@ -17,7 +17,7 @@ import (
 )
 
 type Config struct {
-	InternalEndpoint string // `required:"true"`
+	InternalEndpoint string `required:"true"`
 	ListenAddr       string
 }
 

--- a/backend/json2grpc/main.go
+++ b/backend/json2grpc/main.go
@@ -17,20 +17,24 @@ import (
 )
 
 type Config struct {
-	internalEndpoint string
-	listenAddr       string
+	InternalEndpoint string // `required:"true"`
+	ListenAddr       string
 }
 
 func main() {
 	var conf Config
 	envconfig.MustProcess("", &conf)
-	conn, err := grpc.Dial(
-		conf.internalEndpoint,
+	baseCtx := context.Background()
+	grpcCtx, cancel := context.WithTimeout(baseCtx, 5*time.Second)
+	defer cancel()
+	conn, err := grpc.DialContext(
+		grpcCtx,
+		conf.InternalEndpoint,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithBlock(),
 	)
 	if err != nil {
-		log.Fatal("Connection failed")
+		log.Println("Connection failed in grpc conn initializing", err)
 		return
 	}
 	defer conn.Close()
@@ -38,7 +42,7 @@ func main() {
 	mux := http.NewServeMux()
 	mux.Handle("/sensor", proxy.NewHandler(client))
 	srv := &http.Server{
-		Addr:              conf.listenAddr,
+		Addr:              conf.ListenAddr,
 		Handler:           mux,
 		ReadHeaderTimeout: 3 * time.Second,
 		ReadTimeout:       5 * time.Second,
@@ -53,9 +57,9 @@ func main() {
 	signal.Notify(c, os.Interrupt)
 	<-c
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	shutdownCtx, cancel := context.WithTimeout(baseCtx, 5*time.Second)
 	defer cancel()
-	if err := srv.Shutdown(ctx); err != nil {
+	if err := srv.Shutdown(shutdownCtx); err != nil {
 		log.Print(err)
 	}
 }

--- a/backend/json2grpc/main.go
+++ b/backend/json2grpc/main.go
@@ -18,7 +18,7 @@ import (
 
 type Config struct {
 	InternalEndpoint string `required:"true"`
-	ListenAddr       string
+	ListenAddr       string `default:":8080"`
 }
 
 func main() {


### PR DESCRIPTION
json2grpcをデプロイするためにDockerfileを書きました

動作させるために以下の環境変数を設定する必要があります。

`INTERNALENDPOINT`: 接続をするgRPCサーバのエンドポイント
`LISTENADDR`: リッスンするアドレス。デフォルトは `:8080`