### PR TITLE
disable golangci-lint package cache to silence verbose logs

### DIFF
--- a/.github/workflows/code-test.yml
+++ b/.github/workflows/code-test.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           version: v1.50
           working-directory: ./backend/external/
+          skip-pkg-cache: true
       - name: Build Go binary
         run: |-
           make build
@@ -57,6 +58,7 @@ jobs:
         with:
           version: v1.50
           working-directory: ./backend/internal/
+          skip-pkg-cache: true
       - name: Build Go binary
         run: |-
           make build
@@ -84,6 +86,7 @@ jobs:
         with:
           version: v1.50
           working-directory: ./backend/json2grpc/
+          skip-pkg-cache: true
       - name: Build Go binary
         run: |-
           make build
@@ -127,6 +130,7 @@ jobs:
         with:
           version: v1.50
           working-directory: ./backend/positioning/
+          skip-pkg-cache: true
       - name: Build Go binary
         run: |-
           make build
@@ -169,6 +173,7 @@ jobs:
         with:
           version: v1.50
           working-directory: ./backend/speed/
+          skip-pkg-cache: true
       - name: Build Go binary
         run: |-
           make buildGoBin


### PR DESCRIPTION
`golangci/golangci-lint-action` で

>   Error: /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.28.1/types/pluginpb/plugin.pb.go: Cannot open: File exists

みたいなエラーメッセージが6000行くらい表示されてうるさい。

`actions/setup-go` と `golangci/golangci-lint-action` のパッケージのキャッシュが競合してる気がするので、後者を無効化